### PR TITLE
Add timepicker

### DIFF
--- a/app/(tabs)/timeScreen.tsx
+++ b/app/(tabs)/timeScreen.tsx
@@ -4,22 +4,38 @@ import useViewModel from '@/viewModels/useViewModel'
 import { observer } from 'mobx-react-lite'
 import moment from 'moment'
 import { useEffect, useState } from 'react'
-import { View, Text, Button } from 'react-native'
+import { View, Button } from 'react-native'
 import { StyleSheet } from 'react-native'
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { FormattedTimeDisplay } from '@/components/FormattedTimeDisplay'
 
 
 export default observer(function timeScreen ()  {
   const viewModel = useViewModel(timeScreenVM)
 
-  const { formattedTime, clickCount, incrementClickCount, dispose } = viewModel
+  const {
+    setAlarmTime,
+    showTimePicker,
+    toggleTimePicker,
+    alarmDate,
+  } = viewModel
 
-  useEffect(() => {
-    return () => dispose()
-  }, [viewModel])
+  const handleDateChange = (event: DateTimePickerEvent, date?: Date) => {
+    const { type } = event
+    if (type === 'set' && !!date) {
+      setAlarmTime(date)
+      toggleTimePicker()
+    }
+  }
 
   return <View style={styles.container}>
-    <Text style={styles.title}>The time is currently: {formattedTime}</Text>
-    <Button onPress={incrementClickCount} title={`You have clicked this button: ${clickCount} times`}/>
+    <FormattedTimeDisplay viewModel={viewModel} />
+    <Button onPress={toggleTimePicker} title={`Set a new alarm time`}/>
+    {showTimePicker && <DateTimePicker 
+      mode='time'
+      value={alarmDate}
+      onChange={handleDateChange}
+    />}
   </View>
 })
 
@@ -29,13 +45,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'space-around',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    backgroundColor: 'red',
-    color: 'white',
-    padding: 6,
   },
   separator: {
     marginVertical: 30,

--- a/app/(tabs)/timeScreen.tsx
+++ b/app/(tabs)/timeScreen.tsx
@@ -14,11 +14,16 @@ export default observer(function timeScreen ()  {
   const viewModel = useViewModel(timeScreenVM)
 
   const {
-    setAlarmTime,
-    showTimePicker,
-    toggleTimePicker,
     alarmDate,
+    showTimePicker,
+    dispose,
+    setAlarmTime,
+    toggleTimePicker,
   } = viewModel
+
+  useEffect(() => {
+    return () => dispose()
+  }, [viewModel])
 
   const handleDateChange = (event: DateTimePickerEvent, date?: Date) => {
     const { type } = event

--- a/components/FormattedTimeDisplay.tsx
+++ b/components/FormattedTimeDisplay.tsx
@@ -1,0 +1,19 @@
+import timeScreenVM from "@/viewModels/timeScreenVM/timeScreenVM"
+import { observer } from "mobx-react-lite"
+import { StyleSheet, Text } from "react-native"
+
+
+export const FormattedTimeDisplay = observer((props: {viewModel: timeScreenVM}) => {
+  const { formattedTime } = props.viewModel
+  return <Text style={styles.title}>The time is currently: {formattedTime}</Text>
+})
+
+const styles = StyleSheet.create({
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    backgroundColor: 'red',
+    color: 'white',
+    padding: 6,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
+    "@react-native-community/datetimepicker": "^7.6.2",
     "@react-navigation/native": "^6.0.2",
     "expo": "~50.0.6",
     "expo-font": "~11.10.2",

--- a/viewModels/timeScreenVM/timeScreenVM.tsx
+++ b/viewModels/timeScreenVM/timeScreenVM.tsx
@@ -4,6 +4,9 @@ import moment  from 'moment'
 export default class timeScreenVM {
 
   @observable currentTime = moment()
+  @observable alarmTime = moment()
+  @observable showTimePicker = false
+  @observable alarmEnabled = false
   @observable clickCount = 0
   interval: NodeJS.Timeout
 
@@ -25,6 +28,18 @@ export default class timeScreenVM {
     this.clickCount ++ 
   }
 
+  toggleTimePicker = () => {
+    this.showTimePicker = !this.showTimePicker
+  }
+
+  @computed get alarmDate () {
+    return this.alarmTime.toDate()
+  }
+
+
+  setAlarmTime = (alarmDate: Date) => {
+    this.alarmTime = moment(alarmDate)
+  }
 
   @computed get formattedTime () {
     return this.currentTime.format('HH-mm-ss')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2050,6 +2050,13 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
+"@react-native-community/datetimepicker@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/datetimepicker/-/datetimepicker-7.6.2.tgz#9bba92dc8088b54331f89bbf89134836f0d4c067"
+  integrity sha512-ogZnvCmNG/lGHhEQypqz/mPymiIWD5jv6uKczg/l/aWgiKs1RDPQH1abh+R0I26aKoXmgamJJPuXKeC5eRWtZg==
+  dependencies:
+    invariant "^2.2.4"
+
 "@react-native/assets-registry@0.73.1", "@react-native/assets-registry@~0.73.1":
   version "0.73.1"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.73.1.tgz#e2a6b73b16c183a270f338dc69c36039b3946e85"


### PR DESCRIPTION
# Changes

 - adds timePicker from DateTimePicker library - https://docs.expo.dev/versions/latest/sdk/date-time-picker/
 - adds mobx state values for storing/setting alarm time and toggling whether or not to display the time picker
 - extracts `FormattedTimeDisplay` to own component to avoid re-rendering issue when formatted time changes each second