### PR TITLE
Feat/add timechecker for moment comparison

### DIFF
--- a/components/__tests__/alarmBoolean-test.js
+++ b/components/__tests__/alarmBoolean-test.js
@@ -1,13 +1,18 @@
 import timeScreenVM from '../../viewModels/timeScreenVM/timeScreenVM'
 import {observable} from 'mobx'
 
+const timescreen = new timeScreenVM()
 
 it('returns false if no alarm set', () => {
-
-    const timescreen = new timeScreenVM()
 
     expect(timescreen.alarmEnabled).toEqual(false)
 
     timescreen.dispose()
 
+})
+
+it('can toggle alarm status on', () => {
+    expect(timescreen.toggleAlarmEnabled().alarmEnabled).toEqual(true)
+
+    timescreen.dispose()
 })

--- a/components/__tests__/alarmBoolean-test.js
+++ b/components/__tests__/alarmBoolean-test.js
@@ -1,0 +1,13 @@
+import timeScreenVM from '../../viewModels/timeScreenVM/timeScreenVM'
+import {observable} from 'mobx'
+
+
+it('returns false if no alarm set', () => {
+
+    const timescreen = new timeScreenVM()
+
+    expect(timescreen.alarmEnabled).toEqual(false)
+
+    timescreen.dispose()
+
+})

--- a/components/__tests__/alarmBoolean-test.js
+++ b/components/__tests__/alarmBoolean-test.js
@@ -1,17 +1,17 @@
 import timeScreenVM from '../../viewModels/timeScreenVM/timeScreenVM'
 import {observable} from 'mobx'
 
-const timescreen = new timeScreenVM()
-
 it('returns false if no alarm set', () => {
+    const timescreen = new timeScreenVM()
 
     expect(timescreen.alarmEnabled).toEqual(false)
 
     timescreen.dispose()
-
 })
 
 it('can toggle alarm status on and off', () => {
+    const timescreen = new timeScreenVM()
+
     timescreen.toggleAlarmEnabled()
 
     expect(timescreen.alarmEnabled).toEqual(true)

--- a/components/__tests__/alarmBoolean-test.js
+++ b/components/__tests__/alarmBoolean-test.js
@@ -11,8 +11,14 @@ it('returns false if no alarm set', () => {
 
 })
 
-it('can toggle alarm status on', () => {
-    expect(timescreen.toggleAlarmEnabled().alarmEnabled).toEqual(true)
+it('can toggle alarm status on and off', () => {
+    timescreen.toggleAlarmEnabled()
+
+    expect(timescreen.alarmEnabled).toEqual(true)
+
+    timescreen.toggleAlarmEnabled()
+
+    expect(timescreen.alarmEnabled).toEqual(false)
 
     timescreen.dispose()
 })

--- a/components/__tests__/isSameMinute-test.js
+++ b/components/__tests__/isSameMinute-test.js
@@ -1,6 +1,5 @@
 import moment from 'moment'
 import {timechecker} from '../../helpers/timechecker'
-import expect from 'expect'
 
 const currentTimeString = '2024-02-18 12:00:00'
 

--- a/viewModels/timeScreenVM/timeScreenVM.tsx
+++ b/viewModels/timeScreenVM/timeScreenVM.tsx
@@ -5,6 +5,7 @@ export default class timeScreenVM {
 
   @observable currentTime = moment()
   @observable clickCount = 0
+  @observable alarmEnabled = false
   interval: NodeJS.Timeout
 
   constructor() {

--- a/viewModels/timeScreenVM/timeScreenVM.tsx
+++ b/viewModels/timeScreenVM/timeScreenVM.tsx
@@ -30,4 +30,8 @@ export default class timeScreenVM {
   @computed get formattedTime () {
     return this.currentTime.format('HH-mm-ss')
   }
+
+  toggleAlarmEnabled() {
+    this.alarmEnabled = !this.alarmEnabled
+  }
 }


### PR DESCRIPTION
Refactor to remove an unneeded import. Think I forgot to add this commit last time?

Added a bool to the timeScreenVM class to track alarm status.

Added a test to make sure that a new screen begins with the alarm set to false.

Might refactor into a helper file later (e.g. 'alarmChecker'?)